### PR TITLE
feat(tmux): Add session persistence with continuum

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -62,7 +62,11 @@ bind -n M-Right resize-pane -R 5
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'rose-pine/tmux'
 set -g @rose_pine_variant 'main'
+
+# auto restore
+set -g @continuum-restore 'on'
 
 run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
To prevent the loss of tmux sessions after a system restart, this change introduces automatic session persistence.

- Adds the `tmux-continuum` plugin to the plugin list in `tmux.conf`.
- Enables the `@continuum-restore` option to ensure that sessions are automatically restored when tmux starts.

This setup uses the existing `tpm` plugin manager and complements the already installed `tmux-resurrect` plugin.