### PR TITLE
Add tmux-yank plugin

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -63,6 +63,7 @@ set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
+set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'rose-pine/tmux'
 set -g @rose_pine_variant 'main'
 


### PR DESCRIPTION
Este PR agrega el plugin `tmux-yank` a la configuración de tmux.

## Cambios realizados:
- Agregado `set -g @plugin 'tmux-plugins/tmux-yank'` a la lista de plugins en `tmux/.tmux.conf`

## Beneficios:
- Mejora la funcionalidad de copiado y pegado en tmux
- Integración mejorada con el portapapeles del sistema
- Soporte para copiar texto a diferentes destinos (portapapeles, archivos, etc.)

El plugin se instalará automáticamente la próxima vez que ejecutes `prefix + I` en tmux.