### PR TITLE
style: use Foam for active tmux pane border

### DIFF
--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -82,3 +82,8 @@ set -g @continuum-restore 'on'
 
 # Run TPM last
 run '~/.tmux/plugins/tpm/tpm'
+
+# --- THEME OVERRIDES (must come after TPM so they win over the plugin) ---
+# rose-pine sets the active pane border to Gold (#f6c177); use Foam instead
+# to match the active window-border color from JankyBorders.
+set -g pane-active-border-style "fg=#9ccfd8"


### PR DESCRIPTION
## Motivation

The rose-pine tmux plugin sets the **active pane border** to Gold (`#f6c177`), a yellowish tone that clashed with the rest of the setup. This swaps it for **Foam** (`#9ccfd8`) — the same cool cyan now used for the active *window* border in JankyBorders — so 'focused' reads as Foam consistently across both AeroSpace windows and tmux panes.

## Change

- `tmux/.config/tmux/tmux.conf`: add a theme override **after** the TPM `run` line (so it wins over the plugin):
  ```tmux
  set -g pane-active-border-style "fg=#9ccfd8"
  ```
- Inactive pane border (`#524f67`) left untouched.

## Verification

- `tmux source-file` reloads cleanly.
- Confirmed the override survives a full conf reload (which re-runs the rose-pine plugin), so Foam wins over Gold — verified `pane-active-border-style` = `fg=#9ccfd8` after reload.
- Applied live and confirmed visually.